### PR TITLE
Update HeatMealINjector.cs

### DIFF
--- a/Source/Hot Meals/HeatMealINjector.cs
+++ b/Source/Hot Meals/HeatMealINjector.cs
@@ -59,6 +59,7 @@ public static class HeatMealInjector
 
             return true;
         });
+        Thing heater = null;
         var getHeater = new Toil();
         getHeater.initAction = delegate
         {
@@ -71,7 +72,7 @@ public static class HeatMealInjector
                 table = curJob.GetTarget(tableIndex).Thing;
             }
 
-            var heater = Toils_HeatMeal.FindPlaceToHeatFood(foodToHeat, actor, searchNear: table);
+            heater = Toils_HeatMeal.FindPlaceToHeatFood(foodToHeat, actor, searchNear: table);
             if (heater != null)
             {
                 curJob.SetTarget(finalLocation, heater);
@@ -80,9 +81,6 @@ public static class HeatMealInjector
         yield return getHeater;
         yield return Toils_Jump.JumpIf(empty, delegate
         {
-            var actor = getHeater.actor;
-            var curJob = actor.jobs.curJob;
-            var heater = curJob.GetTarget(finalLocation).Thing;
             return heater == null;
         });
         if (!HotMealsSettings.multipleHeat)


### PR DESCRIPTION
Currently, heater finding logic works like this:
1. save old finalLocation (TargetIndex.C) value to oldFinal
2. getHeater toil finds a place to heat and save it to heater
3. if it is not null, then finalLocation = heater
4. Toil_Jump checks if finalLocation is null, and if it is, then it skips heating process. If it's not null, run heating toil with the finalLocation.

This means that if a current job already has TargetIndex.C, no matter if heater is found, the pawn will go to the TargetIndex.C and do heating job.

The new fixed logic works like this:


1. save old finalLocation (TargetIndex.C) value to oldFinal
2. declare a null heater outside the scope of getHeater toil
3. getHeater toil finds a place to heat and save it to heater
4. if it is not null, then finalLocation = heater
5. Toil_Jump checks if heater is null, and if it is, then it skips heating process. If it's not null, run heating toil with the finalLocation.

This way, Toil_Jump reliably skips heating process if there is no heater found.

Changes: Fix heater finding logic